### PR TITLE
ViewComponent 4.0 and Bridgetown 2.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "bridgetown", ENV["BRIDGETOWN_VERSION"] if ENV["BRIDGETOWN_VERSION"]
+
+group :development do
+  gem "rubocop", require: false
+end

--- a/bridgetown-view-component.gemspec
+++ b/bridgetown-view-component.gemspec
@@ -18,10 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2.0" # Matches  view_component 4.0
 
   spec.add_dependency "bridgetown", ">= 2.0", "< 3.0"
-  spec.add_dependency "view_component", ">= 4.0"
-  # TODO: remove this dependency on actionview once view_component
-  # has this dependency explicitly declared and releases new version: https://github.com/ViewComponent/view_component/pull/2461
-  spec.add_dependency "actionview", [">= 7.1.0", "< 8.1"] # Matches view_component 4.0
+  spec.add_dependency "view_component", ">= 4.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "nokogiri", "~> 1.6"

--- a/bridgetown-view-component.gemspec
+++ b/bridgetown-view-component.gemspec
@@ -15,11 +15,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^spec/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.2.0" # Matches  view_component 4.0
 
-  spec.add_dependency "bridgetown", ">= 1.2.0.beta5", "< 2.0"
-  spec.add_dependency "view_component", ">= 2.49"
-  spec.add_dependency "actionview", ">= 6.0"
+  spec.add_dependency "bridgetown", ">= 2.0", "< 3.0"
+  spec.add_dependency "view_component", ">= 4.0"
+  # TODO: remove this dependency on actionview once view_component
+  # has this dependency explicitly declared and releases new version: https://github.com/ViewComponent/view_component/pull/2461
+  spec.add_dependency "actionview", [">= 7.1.0", "< 8.1"] # Matches view_component 4.0
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "nokogiri", "~> 1.6"

--- a/lib/bridgetown-view-component.rb
+++ b/lib/bridgetown-view-component.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 require "bridgetown-core"
-require "action_view"
-require "view_component"
+require 'action_view'
 
-# Create basic Rails namespace when in Bridgetown-only context
+# Remove this when https://github.com/ViewComponent/view_component/pull/2462 is merged and released.
 unless defined?(Rails)
   module Rails
-    module UrlHelpers; end
-
     def self.version
       ActionView.version.to_s
     end
@@ -19,21 +16,16 @@ unless defined?(Rails)
     end
 
     def self.application
-      @application ||= HashWithDotAccess::Hash.new({
-        routes: { url_helpers: UrlHelpers },
-      })
+      nil
     end
 
     def self.env
-      @env ||= HashWithDotAccess::Hash.new({ production?: Bridgetown.env.production? })
+      @env ||= Bridgetown.environment
     end
   end
-
-  unless Rails.version.to_f >= 6.1
-    require "view_component/render_monkey_patch"
-    ActionView::Base.prepend ViewComponent::RenderMonkeyPatch
-  end
 end
+
+require "view_component"
 
 # Load classes/modules
 
@@ -58,6 +50,10 @@ Bridgetown.initializer :"bridgetown-view-component" do |config|
     klass.class_eval do
       def lookup_context
         HashWithDotAccess::Hash.new(variants: [])
+      end
+
+      def output_buffer
+        ActionView::OutputBuffer.new
       end
 
       def view_renderer

--- a/lib/bridgetown-view-component.rb
+++ b/lib/bridgetown-view-component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bridgetown-core"
-require 'action_view'
+require "action_view"
 
 # Remove this when https://github.com/ViewComponent/view_component/pull/2462 is merged and released.
 unless defined?(Rails)

--- a/lib/bridgetown-view-component/bridgetown/view_component_helpers.rb
+++ b/lib/bridgetown-view-component/bridgetown/view_component_helpers.rb
@@ -42,9 +42,7 @@ module Bridgetown
     end
 
     def helpers
-      @helpers ||= Bridgetown::RubyTemplateView::Helpers.new(
-        self, view_context&.site || Bridgetown::Current.site
-      )
+      super
     end
 
     def method_missing(method, *args, **kwargs, &block)

--- a/lib/bridgetown-view-component/version.rb
+++ b/lib/bridgetown-view-component/version.rb
@@ -2,6 +2,6 @@
 
 module Bridgetown
   module ViewComponent
-    VERSION = "2.0.0"
+    VERSION = "3.0.0"
   end
 end

--- a/spec/bridgetown-view-component_spec.rb
+++ b/spec/bridgetown-view-component_spec.rb
@@ -2,40 +2,38 @@
 
 require "spec_helper"
 
-describe(Bridgetown::ViewComponent) do
-  let(:overrides) { {} }
-  let(:config) do
-    Bridgetown.configuration(Bridgetown::Utils.deep_merge_hashes({
-      "full_rebuild" => true,
-      "root_dir"     => root_dir,
-      "source"       => source_dir,
-      "destination"  => dest_dir,
-    }, overrides)).tap do |conf|
-      conf.run_initializers! context: :static
-    end
-  end
-  let(:metadata_overrides) { {} }
-  let(:metadata_defaults) do
-    {
-      "name" => "My Awesome Site",
-      "author" => {
-        "name" => "Ada Lovejoy",
-      }
-    }
-  end
-  let(:site) { Bridgetown::Site.new(config) }
-  let(:contents) { File.read(dest_dir("index.html")) }
-  before(:each) do
-    metadata = metadata_defaults.merge(metadata_overrides).to_yaml.sub("---\n", "")
-    File.write(source_dir("_data/site_metadata.yml"), metadata)
-    site.process
-    FileUtils.rm(source_dir("_data/site_metadata.yml"))
+describe "bridgetown-view-component (integration)" do
+  include_context "bridgetown built site"
+
+  it "renders a ViewComponent with slots from a page" do
+    contents = read_output("index.html")
+    expect(contents).to include("Greetings Bridgetown")
+    expect(contents).to include("<hr>\n")
+    expect(contents).to include("<strong>Post 1</strong> <span>-&gt;</span>")
+    expect(contents).to include("<strong>Post 2</strong> <span>-&gt;</span>")
   end
 
-  it "outputs the rendered ViewComponent" do
-    expect(contents).to match "Greetings Bridgetown"
-    expect(contents).to match "<hr>\n"
-    expect(contents).to match "<strong>Post 1</strong> <span>-&gt;</span>"
-    expect(contents).to match "<strong>Post 2</strong> <span>-&gt;</span>"
+  it "renders nested ViewComponents" do
+    contents = read_output("nested.html")
+    expect(contents).to include("Nested List:")
+    expect(contents).to include("Nested Item: One")
+    expect(contents).to include("Nested Item: Two")
+  end
+
+  it "exposes Bridgetown helpers inside ViewComponent templates" do
+    contents = read_output("helpers-access.html")
+    expect(contents).to include('class="primary"')
+    expect(contents).to include("<strong>From Bridgetown helper</strong>")
+  end
+
+  it "supports allow_rails_helpers :tag (ActionView TagHelper)" do
+    contents = read_output("header-component.html")
+    expect(contents).to include("<h1")
+    expect(contents).to include("my-8 text-3xl font-bold tracking-tight text-primary-white sm:text-4xl")
+  end
+
+  it "supports returning a html_safe string from call" do
+    contents = read_output("safe-call.html")
+    expect(contents).to include("<strong>Safe Call</strong>")
   end
 end

--- a/spec/fixtures/src/_components/header_component.rb
+++ b/spec/fixtures/src/_components/header_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class HeaderComponent < ViewComponent::Base
+  Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
+  include Bridgetown::ViewComponentHelpers
+
+  def call
+    tag.h1 content, class: "my-8 text-3xl font-bold tracking-tight text-primary-white sm:text-4xl"
+  end
+end
+

--- a/spec/fixtures/src/_components/helpers_access_vc.rb
+++ b/spec/fixtures/src/_components/helpers_access_vc.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class HelpersAccessVc < ViewComponent::Base
+  include Bridgetown::ViewComponentHelpers
+
+  erb_template <<~ERB
+    <div class="<%= class_map(primary: true, secondary: false) %>">
+      <%= markdownify "**From Bridgetown helper**" %>
+    </div>
+  ERB
+end
+

--- a/spec/fixtures/src/_components/nested_item_vc.rb
+++ b/spec/fixtures/src/_components/nested_item_vc.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NestedItemVc < ViewComponent::Base
+  include Bridgetown::ViewComponentHelpers
+
+  def initialize(text:)
+    @text = text
+  end
+
+  erb_template <<~ERB
+    Nested Item: <%= @text %>
+  ERB
+end
+

--- a/spec/fixtures/src/_components/nested_list_vc.rb
+++ b/spec/fixtures/src/_components/nested_list_vc.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class NestedListVc < ViewComponent::Base
+  include Bridgetown::ViewComponentHelpers
+
+  def initialize(items:)
+    @items = items
+  end
+
+  erb_template <<~ERB
+    Nested List:
+    <ul>
+      <% @items.each do |item| %>
+        <li><%= render NestedItemVc.new(text: item) %></li>
+      <% end %>
+    </ul>
+  ERB
+end
+

--- a/spec/fixtures/src/_components/safe_call_vc.rb
+++ b/spec/fixtures/src/_components/safe_call_vc.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SafeCallVc < ViewComponent::Base
+  include Bridgetown::ViewComponentHelpers
+
+  def call
+    "<strong>Safe Call</strong>".html_safe
+  end
+end
+

--- a/spec/fixtures/src/_layouts/default.html
+++ b/spec/fixtures/src/_layouts/default.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     THIS IS MY LAYOUT
-    {{ content }}
+    <%= content %>
   </body>
 </html>

--- a/spec/fixtures/src/header_component.erb
+++ b/spec/fixtures/src/header_component.erb
@@ -1,0 +1,7 @@
+---
+layout: default
+permalink: /header-component.html
+---
+
+<%= render HeaderComponent.new.with_content("") %>
+

--- a/spec/fixtures/src/helpers_access_component.erb
+++ b/spec/fixtures/src/helpers_access_component.erb
@@ -1,0 +1,7 @@
+---
+layout: default
+permalink: /helpers-access.html
+---
+
+<%= render HelpersAccessVc.new %>
+

--- a/spec/fixtures/src/nested_view_components.erb
+++ b/spec/fixtures/src/nested_view_components.erb
@@ -1,0 +1,7 @@
+---
+layout: default
+permalink: /nested.html
+---
+
+<%= render NestedListVc.new(items: ["One", "Two"]) %>
+

--- a/spec/fixtures/src/safe_call_component.erb
+++ b/spec/fixtures/src/safe_call_component.erb
@@ -1,0 +1,7 @@
+---
+layout: default
+permalink: /safe-call.html
+---
+
+<%= render SafeCallVc.new %>
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bridgetown"
+require "tmpdir"
 
 Bridgetown.begin!
 
@@ -8,6 +9,7 @@ Bridgetown.begin!
 Bridgetown::Site # resolve weird autoload issue
 # rubocop:enable Lint/Void
 require File.expand_path("../lib/bridgetown-view-component", __dir__)
+require_relative "support/bridgetown_site_context"
 
 Bridgetown.logger.log_level = :error
 
@@ -18,7 +20,6 @@ RSpec.configure do |config|
 
   ROOT_DIR = File.expand_path("fixtures", __dir__)
   SOURCE_DIR = File.join(ROOT_DIR, "src")
-  DEST_DIR   = File.expand_path("dest", __dir__)
 
   def root_dir(*files)
     File.join(ROOT_DIR, *files)
@@ -26,13 +27,5 @@ RSpec.configure do |config|
 
   def source_dir(*files)
     File.join(SOURCE_DIR, *files)
-  end
-
-  def dest_dir(*files)
-    File.join(DEST_DIR, *files)
-  end
-
-  def make_context(registers = {})
-    Liquid::Context.new({}, {}, { :site => site }.merge(registers))
   end
 end

--- a/spec/support/bridgetown_site_context.rb
+++ b/spec/support/bridgetown_site_context.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "bridgetown built site" do
+  def bridgetown_config_overrides
+    {}
+  end
+
+  def bridgetown_site_metadata
+    {
+      "name" => "My Awesome Site",
+      "author" => { "name" => "Ada Lovejoy" },
+    }
+  end
+
+  before(:context) do
+    @destination_dir = Dir.mktmpdir("bridgetown-vc-dest")
+
+    metadata = bridgetown_site_metadata.to_yaml.sub("---\n", "")
+    File.write(source_dir("_data/site_metadata.yml"), metadata)
+
+    @config = Bridgetown.configuration(Bridgetown::Utils.deep_merge_hashes({
+      "full_rebuild" => true,
+      "root_dir"     => root_dir,
+      "source"       => source_dir,
+      "destination"  => @destination_dir,
+    }, bridgetown_config_overrides)).tap do |conf|
+      conf.run_initializers! context: :static
+    end
+
+    @site = Bridgetown::Site.new(@config)
+    @site.process
+  end
+
+  after(:context) do
+    FileUtils.rm_f(source_dir("_data/site_metadata.yml"))
+    FileUtils.remove_entry(@destination_dir) if @destination_dir && File.exist?(@destination_dir)
+
+    @destination_dir = @config = @site = nil
+  end
+
+  def destination_dir = @destination_dir
+  def config = @config
+  def site = @site
+
+  def read_output(relative_path)
+    File.read(File.join(destination_dir, relative_path))
+  end
+end
+


### PR DESCRIPTION
The aim of this PR is to bring bridgetown-view-component to the latest version of bridgetown (2.0) and view_component (4.0).

# TODO
- [x] Upgrade ViewComponent to 4.0
- [x] Support Bridgetown 2.0
- [x] Fix spec
  - [x] Not rendering liquid layout
- [x] https://github.com/ViewComponent/view_component/pull/2461
- [x] https://github.com/ViewComponent/view_component/pull/2462

# How to try this

For anyone wanting to try this on a project and give feedback.

Add this to your bridgetown Gemfile:

```ruby
gem "bridgetown-view-component", github: 'mikz/bridgetown-view-component', branch: 'bridgetown-2-support'
```


